### PR TITLE
Fixed failures when attempting to Clear() Dropdowns and postcode string conversion

### DIFF
--- a/BizCover.Test.QA/Pages/CreateAnAccountPage.cs
+++ b/BizCover.Test.QA/Pages/CreateAnAccountPage.cs
@@ -67,12 +67,12 @@ namespace BizCover.Test.QA.Pages
             City.Clear();
             City.SendKeys(city);
             
-            State.Clear();
+            //State.Clear();
             State.SendKeys(state);
 
             PostCode.Clear();
             PostCode.SendKeys(postcode.ToString());
-            Country.Clear();
+            //Country.Clear();
             Country.SendKeys(country);
 
 

--- a/BizCover.Test.QA/Steps/CreateAccountSteps.cs
+++ b/BizCover.Test.QA/Steps/CreateAccountSteps.cs
@@ -54,8 +54,10 @@ namespace BizCover.Test.QA.Steps
         [When(@"I Register my Address Details")]
         public void WhenIRegisterMyAddressDetails(Table table)
         {
-            _ScenarioData = table.CreateDynamicInstance();
-            CreateAnAccountPage.EnterYourAddressDetails((string)_ScenarioData.FirstName, (string)_ScenarioData.LastName, (string)_ScenarioData.Company, (string)_ScenarioData.Address1, (string)_ScenarioData.Address2, (string)_ScenarioData.City, (string)_ScenarioData.State, (string)_ScenarioData.PostCode, (string)_ScenarioData.Country);
+            dynamic _ScenarioData = table.CreateDynamicInstance();
+            string postCode = _ScenarioData.PostCode.ToString();
+
+            CreateAnAccountPage.EnterYourAddressDetails((string)_ScenarioData.FirstName, (string)_ScenarioData.LastName, (string)_ScenarioData.Company, (string)_ScenarioData.Address1, (string)_ScenarioData.Address2, (string)_ScenarioData.City, (string)_ScenarioData.State, postCode, (string)_ScenarioData.Country);
         }
 
         [When(@"I click Create Account")]


### PR DESCRIPTION
Fixed failures when attempting to Clear() Dropdowns 
Enabled the int conversion to string for postcode